### PR TITLE
Set method

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ if (exports.FormData) {
   };
 
   /**
-   * Set new value of an existing key (first found) or adds key/value if does not already exist.
+   * Set new value of all existing values with the new one or adds key/value if does not already exist.
    * @param fieldName          String                    Form field name
    * @param data               object|string             An object or string field value.
    *
@@ -86,13 +86,16 @@ if (exports.FormData) {
     if (typeof data === 'string') {
         file = {data: data, content_type: 'text/plain'};
     }
+    var isNew = true;
     for(var i=0; i < this.parts.length; i++){
       if(this.parts[i].field == fieldName){
         this.parts[i].file = file;
-        return
+        isNew = false;
       }
     }
-    this.parts.push({field: fieldName, file: file});
+    if (isNew) {
+      this.parts.push({field: fieldName, file: file});
+    }
   }
   
   /**

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ if (exports.FormData) {
     if (arguments.length < 2) {
       throw new SyntaxError('Not enough arguments');
     }
-    let file = data;
+    var file = data;
     if (typeof data === 'string') {
         file = {data: data, content_type: 'text/plain'};
     }

--- a/index.js
+++ b/index.js
@@ -66,6 +66,34 @@ if (exports.FormData) {
     }
     this.parts.push({field: fieldName, file: file});
   };
+
+  /**
+   * Set new value of an existing key (first found) or adds key/value if does not already exist.
+   * @param fieldName          String                    Form field name
+   * @param data               object|string             An object or string field value.
+   *
+   * If data is an object, it should match the structure of k6's http.FileData
+   * object (returned by http.file()) and consist of:
+   * @param data.data          String|Array|ArrayBuffer  File data
+   * @param data.filename      String                    Optional file name
+   * @param data.content_type  String                    Optional content type, default is application/octet-stream
+   **/
+  FormData.prototype.set = function(fieldName, data){
+    if (arguments.length < 2) {
+      throw new SyntaxError('Not enough arguments');
+    }
+    let file = data;
+    if (typeof data === 'string') {
+        file = {data: data, content_type: 'text/plain'};
+    }
+    for(var i=0; i < this.parts.length; i++){
+      if(this.parts[i].field == fieldName){
+        this.parts[i].file = file;
+        return
+      }
+    }
+    this.parts.push({field: fieldName, file: file});
+  }
   
   /**
    * Return the assembled request body as an ArrayBuffer.


### PR DESCRIPTION
Mimic the [Web API FormData() set method](https://developer.mozilla.org/en-US/docs/Web/API/FormData/set) to allow for existing keys in the FormData object to be updated or add if it does not already exist.

Note it is currently possible to have multiple entries with the same key in the FormData array, this set method will only updates the first entry that is found.
