### PR TITLE
Adding CODEOWNERS, issue auto-assigner

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -1,0 +1,11 @@
+name: "Auto assign maintainer to issue"
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign-maintainer:
+    uses: grafana/k6/.github/workflows/issue-auto-assign.yml@master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @grafana/k6-core


### PR DESCRIPTION
# What?

Adding the CODEOWNERS and issues auto-assigner to the project.

# Why?

This helps us with the discovery of the PRs and issues that are opened in this repository.