### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,4 @@ Data flows one way: field values in, serialized ArrayBuffer out. The caller pass
 - The module uses CommonJS-style `exports.FormData` assignment, but k6's module system treats it as a named export. Standard Node.js or browser semantics do not apply.
 - `index.js` contains a top-level `return` (early-exit guard); k6's CommonJS module wrapper tolerates this, but it is not valid in a standard ES module.
 - Code style is enforced by `.editorconfig` only (no Prettier/ESLint).
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
